### PR TITLE
Fixing reading of non-array exif values

### DIFF
--- a/src/Helpers/Formatter.php
+++ b/src/Helpers/Formatter.php
@@ -20,7 +20,7 @@ class Formatter
 
     public static function exif(array $data): array
     {
-        $data = array_filter($data, fn ($value) => is_string($value) && ! empty($value));
+        $data = array_filter($data, fn ($value) => !is_array($value) && ! empty($value));
 
         return array_change_key_case($data, CASE_LOWER);
     }


### PR DESCRIPTION
Currently the add-on is dropping some values.

Example:
The information provided to the Formatter contained this line:
`"ISOSpeedRatings":100,`

However, this line did no longer show up in the formatted array of values returned. The reason is that PHP returns `false` when you use `is_string()` on e.g. an integer value. It worked for fractions (e.g. "1/180") as they are saved as strings, but anything with a numeric value was being dropped.

I assume you added this line in order to ignore entries where an array is returned as a value, which is why I replaced `is_string` with `!is_array`.

Thanks for the add-on, saved me from having to write my own. :)